### PR TITLE
Add withprogress and logprogress macros

### DIFF
--- a/src/ProgressLogging.jl
+++ b/src/ProgressLogging.jl
@@ -70,10 +70,10 @@ function _withprogress(kwarg, ex)
     end
     name = kwarg.args[2]
 
-    @gensym progress_id name_var
+    @gensym name_var
     m = @__MODULE__
     quote
-        let $_id_name = $(QuoteNode(progress_id)),
+        let $_id_name = gensym(:progress_id),
             $name_var = $name
             $m.@logprogress $name_var progress = NaN
             try

--- a/test/test_withprogress_macro.jl
+++ b/test/test_withprogress_macro.jl
@@ -1,0 +1,71 @@
+module TestWithprogressMacro
+
+using Logging
+using ProgressLogging
+using ProgressLogging: ProgressLevel
+using Test
+using Test: collect_test_logs
+
+@testset "simple" begin
+    logs, = collect_test_logs(min_level = ProgressLevel) do
+        @withprogress @logprogress "hello" progress = 0.1
+    end
+    @test length(logs) == 3
+    @test logs[1].kwargs[:progress] === NaN
+    @test logs[2].kwargs[:progress] === 0.1
+    @test logs[3].kwargs[:progress] === "done"
+    @test length(unique([l.id for l in logs])) == 1
+end
+
+@testset "with name" begin
+    logs, = collect_test_logs(min_level = ProgressLevel) do
+        @withprogress name = "name" @logprogress "hello" progress = 0.1
+    end
+    @test length(logs) == 3
+    @test logs[1].kwargs[:progress] === NaN
+    @test logs[2].kwargs[:progress] === 0.1
+    @test logs[3].kwargs[:progress] === "done"
+    @test logs[1].message === "name"
+    @test logs[2].message === "hello"
+    @test logs[3].message === "name"
+    @test length(unique([l.id for l in logs])) == 1
+end
+
+@testset "nested" begin
+    logs, = collect_test_logs(min_level = ProgressLevel) do
+        @withprogress begin
+            @logprogress "hello" progress = 0.1
+            @withprogress begin
+                @logprogress "world" progress = 0.2
+            end
+        end
+    end
+
+    @test length(logs) == 6
+
+    ids = unique([l.id for l in logs])
+    @test length(ids) == 2
+
+    @test Tuple((l.id, l.message, l.kwargs[:progress]) for l in logs) === (
+        (ids[1], "", NaN),
+        (ids[1], "hello", 0.1),
+        (ids[2], "", NaN),
+        (ids[2], "world", 0.2),
+        (ids[2], "", "done"),
+        (ids[1], "", "done"),
+    )
+end
+
+@testset "invalid input" begin
+    local err
+    @test try
+        @eval @withprogress invalid_argument = "" nothing
+    catch err
+        err
+    end isa Exception  # unfortunately `LoadError`, not an `ArgumentError`
+    msg = sprint(showerror, err)
+    @test occursin("First expression to @withprogress must be `name=...`.", msg)
+    @test occursin("invalid_argument", msg)
+end
+
+end  # module


### PR DESCRIPTION
Quoting the docstring:

> ```julia
> @withprogress [name=""] ex
> ```
>
> Create a lexical environment in which [`@logprogress`](@ref) can be used to emit progress log events without manually specifying the log level and `_id`.
>
> ```julia
> @withprogress begin
>     for i = 1:10
>         sleep(0.5)
>         @logprogress "iterating" progress=i/10
>     end
> end
> ```

An example usecase:
https://github.com/tkf/Transducers.jl/pull/64/commits/f94ebc05497812dbd9f4e8b19c524d5fa21468eb#diff-c7e0e286be94a49828209e9f88753e8b

This lets people use somewhat low-level logging-base API (`@withprogress` and `@logprogress`) without referring to the lowest-level specification (`_id` and `LogLevel`).
