### PR TITLE
Simplify at-logprogress call signature

### DIFF
--- a/test/test_withprogress_macro.jl
+++ b/test/test_withprogress_macro.jl
@@ -34,6 +34,18 @@ end
     @test length(unique([l.id for l in logs])) == 1
 end
 
+@testset "keyword argument when no name" begin
+    logs, = collect_test_logs(min_level = ProgressLevel) do
+        @withprogress @logprogress 0.1 message = "hello"
+    end
+    @test length(logs) == 3
+    @test logs[1].kwargs[:progress] === NaN
+    @test logs[2].kwargs[:progress] === 0.1
+    @test logs[3].kwargs[:progress] === "done"
+    @test logs[2].kwargs[:message] === "hello"
+    @test length(unique([l.id for l in logs])) == 1
+end
+
 @testset "change name" begin
     logs, = collect_test_logs(min_level = ProgressLevel) do
         @withprogress name = "name" @logprogress "hello" 0.1

--- a/test/test_withprogress_macro.jl
+++ b/test/test_withprogress_macro.jl
@@ -6,20 +6,37 @@ using ProgressLogging: ProgressLevel
 using Test
 using Test: collect_test_logs
 
-@testset "simple" begin
+@testset "specify name in `@logprogress`" begin
     logs, = collect_test_logs(min_level = ProgressLevel) do
-        @withprogress @logprogress "hello" progress = 0.1
+        @withprogress @logprogress "hello" 0.1
     end
     @test length(logs) == 3
     @test logs[1].kwargs[:progress] === NaN
     @test logs[2].kwargs[:progress] === 0.1
     @test logs[3].kwargs[:progress] === "done"
+    @test logs[1].message === ""
+    @test logs[2].message === "hello"
+    @test logs[3].message === ""
     @test length(unique([l.id for l in logs])) == 1
 end
 
-@testset "with name" begin
+@testset "specify name in `@withprogress`" begin
     logs, = collect_test_logs(min_level = ProgressLevel) do
-        @withprogress name = "name" @logprogress "hello" progress = 0.1
+        @withprogress name = "hello" @logprogress 0.1
+    end
+    @test length(logs) == 3
+    @test logs[1].kwargs[:progress] === NaN
+    @test logs[2].kwargs[:progress] === 0.1
+    @test logs[3].kwargs[:progress] === "done"
+    @test logs[1].message === "hello"
+    @test logs[2].message === "hello"
+    @test logs[3].message === "hello"
+    @test length(unique([l.id for l in logs])) == 1
+end
+
+@testset "change name" begin
+    logs, = collect_test_logs(min_level = ProgressLevel) do
+        @withprogress name = "name" @logprogress "hello" 0.1
     end
     @test length(logs) == 3
     @test logs[1].kwargs[:progress] === NaN
@@ -34,9 +51,9 @@ end
 @testset "nested" begin
     logs, = collect_test_logs(min_level = ProgressLevel) do
         @withprogress begin
-            @logprogress "hello" progress = 0.1
+            @logprogress "hello" 0.1
             @withprogress begin
-                @logprogress "world" progress = 0.2
+                @logprogress "world" 0.2
             end
         end
     end


### PR DESCRIPTION
Before

```julia
@withprogress begin
    for i = 1:10
        sleep(0.5)
        @logprogress "iterating" progress=i/10
    end
end
```

After

```julia
@withprogress name="iterating" begin
    for i = 1:10
        sleep(0.5)
        @logprogress i/10
    end
end
```

The motivation is to make the default invocation of `@logprogress` as simple as possible (just a single positional argument). This will avoid distracting the main logic of the main code surrounding `@logprogress`.

Changes to the previous version:

* `progress` is a positional and the only mandatory argument
* `name` argument is optional; the value set by `@withprogress` is used automatically.

ref: https://github.com/JunoLab/ProgressLogging.jl/issues/7#issuecomment-545828524
