### PR TITLE
Implement type-based API for progress records

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,8 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 julia = "0.7, 1"
 
 [extras]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Random"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 julia = "0.7, 1"

--- a/src/ProgressLogging.jl
+++ b/src/ProgressLogging.jl
@@ -6,8 +6,32 @@ module ProgressLogging
 export @progress, @progressid, @withprogress, @logprogress
 
 using Base.Meta: isexpr
-using UUIDs: UUID, uuid4, uuid5
+using UUIDs: UUID, uuid4
 using Logging: Logging, @logmsg, LogLevel
+
+if VERSION >= v"1.1-"
+    using UUIDs: uuid5
+else
+    import SHA
+    function uuid5(ns::UUID, name::String)
+        nsbytes = zeros(UInt8, 16)
+        nsv = ns.value
+        for idx in Base.OneTo(16)
+            nsbytes[idx] = nsv >> 120
+            nsv = nsv << 8
+        end
+        hash_result = SHA.sha1(append!(nsbytes, convert(Vector{UInt8}, codeunits(unescape_string(name)))))
+        # set version number to 5
+        hash_result[7] = (hash_result[7] & 0x0F) | (0x50)
+        hash_result[9] = (hash_result[9] & 0x3F) | (0x80)
+        v = zero(UInt128)
+        #use only the first 16 bytes of the SHA1 hash
+        for idx in Base.OneTo(16)
+            v = (v << 0x08) | hash_result[idx]
+        end
+        return UUID(v)
+    end
+end
 
 const ProgressLevel = LogLevel(-1)
 

--- a/src/ProgressLogging.jl
+++ b/src/ProgressLogging.jl
@@ -187,6 +187,11 @@ Base.convert(::Type{ProgressString}, str::ProgressString) = str
 Base.convert(::Type{T}, str::ProgressString) where {T<:AbstractString} =
     convert(T, str.progress.name)
 
+# Define `cmp` to make `==` etc. work
+Base.cmp(a::AbstractString, b::ProgressString) = cmp(a, string(b))
+Base.cmp(a::ProgressString, b::AbstractString) = cmp(string(a), b)
+Base.cmp(a::ProgressString, b::ProgressString) = cmp(string(a), string(b))
+
 # Avoid using `show(::IO, ::AbstractString)` which expects
 # `Base.print_quoted` to work.
 function Base.show(io::IO, str::ProgressString)

--- a/src/ProgressLogging.jl
+++ b/src/ProgressLogging.jl
@@ -175,7 +175,8 @@ end
 
 asprogress(_level, str::ProgressString, _args...; _...) = str.progress
 
-Base.print(io::IO, str::ProgressString) = print(io, str.progress.name)
+Base.string(str::ProgressString) = str.progress.name
+Base.print(io::IO, str::ProgressString) = print(io, string(str))
 Base.convert(::Type{ProgressString}, str::ProgressString) = str
 Base.convert(::Type{T}, str::ProgressString) where {T<:AbstractString} =
     convert(T, str.progress.name)

--- a/src/ProgressLogging.jl
+++ b/src/ProgressLogging.jl
@@ -298,7 +298,7 @@ macro logprogress(name, progress = nothing, args...)
         kwargs = (:(progress = $progress), args...)
     end
 
-    id_err = "`@logprogress` must be used inside @withprogress or `_id` keyword argument"
+    id_err = "`@logprogress` must be used inside `@withprogress` or with `_id` keyword argument"
     id_expr = :($Base.@isdefined($_id_var) ? $_id_var : $error($id_err))
     for x in kwargs
         if isexpr(x, :(=)) && x.args[1] === :_id

--- a/src/ProgressLogging.jl
+++ b/src/ProgressLogging.jl
@@ -164,8 +164,7 @@ end
 
 asprogress(_level, str::ProgressString, _args...; _...) = str.progress
 
-Base.string(str::ProgressString) = str.progress.name
-Base.print(io::IO, str::ProgressString) = print(io, string(str))
+Base.print(io::IO, str::ProgressString) = print(io, str.progress.name)
 Base.convert(::Type{ProgressString}, str::ProgressString) = str
 Base.convert(::Type{T}, str::ProgressString) where {T<:AbstractString} =
     convert(T, str.progress.name)

--- a/src/ProgressLogging.jl
+++ b/src/ProgressLogging.jl
@@ -180,9 +180,11 @@ Base.convert(::Type{ProgressString}, str::ProgressString) = str
 Base.convert(::Type{T}, str::ProgressString) where {T<:AbstractString} =
     convert(T, str.progress.name)
 
+# Avoid using `show(::IO, ::AbstractString)` which expects
+# `Base.print_quoted` to work.
 function Base.show(io::IO, str::ProgressString)
     if get(io, :typeinfo, Any) === ProgressString
-        show(io, string(str.progress))
+        show(io, string(str))
         return
     end
     print(io, @__MODULE__, ".")

--- a/src/ProgressLogging.jl
+++ b/src/ProgressLogging.jl
@@ -131,7 +131,7 @@ end
 const PROGRESS_LOGGING_UUID_NS = UUID("1e962757-ea70-431a-b9f6-aadf988dcb7f")
 
 asuuid(id::UUID) = id
-asuuid(id) = uuid5(PROGRESS_LOGGING_UUID_NS, string(id))
+asuuid(id) = uuid5(PROGRESS_LOGGING_UUID_NS, repr(id))
 
 
 """

--- a/src/ProgressLogging.jl
+++ b/src/ProgressLogging.jl
@@ -170,17 +170,6 @@ Base.convert(::Type{ProgressString}, str::ProgressString) = str
 Base.convert(::Type{T}, str::ProgressString) where {T<:AbstractString} =
     convert(T, str.progress.name)
 
-function Base.show(io::IO, str::ProgressString)
-    if get(io, :typeinfo, Any) === ProgressString
-        show(io, string(str.progress))
-        return
-    end
-    print(io, @__MODULE__, ".")
-    print(io, "ProgressString(")
-    show(io, str.progress)
-    print(io, ")")
-end
-
 """
     progress(f::Function; name = "")
 

--- a/src/ProgressLogging.jl
+++ b/src/ProgressLogging.jl
@@ -175,7 +175,13 @@ end
 
 asprogress(_level, str::ProgressString, _args...; _...) = str.progress
 
+# Since `Base.string(::AbstractString)` is defined to be an `identity`
+# function, we overload it to make sure that `string(message)`
+# typically used in the loggers converts `ProgressString` to a vanilla
+# `String` as soon as possible.  It may not be needed if we define
+# `ProgressString` perfectly.  But let's play on the safe side.
 Base.string(str::ProgressString) = str.progress.name
+
 Base.print(io::IO, str::ProgressString) = print(io, string(str))
 Base.convert(::Type{ProgressString}, str::ProgressString) = str
 Base.convert(::Type{T}, str::ProgressString) where {T<:AbstractString} =

--- a/src/ProgressLogging.jl
+++ b/src/ProgressLogging.jl
@@ -29,7 +29,7 @@ Progress log record can be created by using the following pattern
 id = uuid4()
 try
     @info Progress(id)  # create a progress bar
-    # some time consuming task
+    # some time consuming job
     # ...
     @info Progress(id, 0.1)  # update progress to 10%
     # ...
@@ -53,14 +53,14 @@ progress-related information from the following properties.
   - `0 <= fraction < 1`
   - `fraction >= 1`: completed
   - `fraction = nothing`: indeterminate progress
-- `id::UUID`: Identifier of the task whose progress is at `fraction`.
+- `id::UUID`: Identifier of the job whose progress is at `fraction`.
 - `parentid::UUID`: The ID of the parent progress.  It is set to
   [`ProgressLogging.ROOTID`](@ref) when there is no parent progress.
-  This is used for representing progresses of nested tasks.  Note that
-  sub-tasks may be executed concurrently; i.e., there can be multiple
-  child tasks for one parent task.
+  This is used for representing progresses of nested jobs.  Note that
+  sub-jobs may be executed concurrently; i.e., there can be multiple
+  child jobs for one parent job.
 - `name::String`: Name of the progress bar.
-- `done::Bool`: `true` if the task is done.
+- `done::Bool`: `true` if the job is done.
 """
 struct Progress
     id::UUID

--- a/src/ProgressLogging.jl
+++ b/src/ProgressLogging.jl
@@ -129,12 +129,23 @@ end
 ```
 """
 asprogress(_level, progress::Progress, _args...; _...) = progress
-asprogress(_level, name, _module, _group, id, _file, _line; progress = undef, kwargs...) =
+function asprogress(
+    _level,
+    name,
+    _module,
+    _group,
+    id,
+    _file,
+    _line;
+    progress = undef,  # `undef` is an arbitrary unsupported value
+    kwargs...,
+)
     if progress isa Union{Nothing,Real,AbstractString}
-        _asprogress(name, id; progress = progress, kwargs...)
+        return _asprogress(name, id; progress = progress, kwargs...)
     else
-        nothing
+        return nothing
     end
+end
 
 # `parentid` is used from `@logprogress`.
 function _asprogress(name, id, parentid = ROOTID; progress, _...)

--- a/src/ProgressLogging.jl
+++ b/src/ProgressLogging.jl
@@ -180,6 +180,17 @@ Base.convert(::Type{ProgressString}, str::ProgressString) = str
 Base.convert(::Type{T}, str::ProgressString) where {T<:AbstractString} =
     convert(T, str.progress.name)
 
+function Base.show(io::IO, str::ProgressString)
+    if get(io, :typeinfo, Any) === ProgressString
+        show(io, string(str.progress))
+        return
+    end
+    print(io, @__MODULE__, ".")
+    print(io, "ProgressString(")
+    show(io, str.progress)
+    print(io, ")")
+end
+
 """
     progress(f::Function; name = "")
 

--- a/test/test_progress_record.jl
+++ b/test/test_progress_record.jl
@@ -1,0 +1,19 @@
+module TestProgressRecord
+
+using ProgressLogging: Progress, ProgressString
+using Random: shuffle!
+using Test
+using UUIDs: uuid4
+
+@testset "cmp: ProgressString" begin
+    strings = Any[
+        let s = string(i)
+            rand(Bool) ? s : ProgressString(Progress(uuid4(), 0.0; name = s))
+        end
+        for i in 10:99
+    ]
+    shuffle!(strings)
+    @test string.(sort!(strings)) == string.(10:99)
+end
+
+end  # module

--- a/test/test_withprogress_macro.jl
+++ b/test/test_withprogress_macro.jl
@@ -14,9 +14,9 @@ using Test: collect_test_logs
     @test logs[1].kwargs[:progress] === NaN
     @test logs[2].kwargs[:progress] === 0.1
     @test logs[3].kwargs[:progress] === "done"
-    @test logs[1].message === ""
-    @test logs[2].message === "hello"
-    @test logs[3].message === ""
+    @test logs[1].message == ""
+    @test logs[2].message == "hello"
+    @test logs[3].message == ""
     @test length(unique([l.id for l in logs])) == 1
 end
 
@@ -28,9 +28,9 @@ end
     @test logs[1].kwargs[:progress] === NaN
     @test logs[2].kwargs[:progress] === 0.1
     @test logs[3].kwargs[:progress] === "done"
-    @test logs[1].message === "hello"
-    @test logs[2].message === "hello"
-    @test logs[3].message === "hello"
+    @test logs[1].message == "hello"
+    @test logs[2].message == "hello"
+    @test logs[3].message == "hello"
     @test length(unique([l.id for l in logs])) == 1
 end
 
@@ -54,9 +54,9 @@ end
     @test logs[1].kwargs[:progress] === NaN
     @test logs[2].kwargs[:progress] === 0.1
     @test logs[3].kwargs[:progress] === "done"
-    @test logs[1].message === "name"
-    @test logs[2].message === "hello"
-    @test logs[3].message === "name"
+    @test logs[1].message == "name"
+    @test logs[2].message == "hello"
+    @test logs[3].message == "name"
     @test length(unique([l.id for l in logs])) == 1
 end
 

--- a/test/test_withprogress_macro.jl
+++ b/test/test_withprogress_macro.jl
@@ -123,4 +123,26 @@ end
     @test occursin("invalid_argument", msg)
 end
 
+module IsolatedNamespace
+import ProgressLogging
+using Test: @test, @testset, collect_test_logs
+@testset "IsolatedNamespace" begin
+    logs, = collect_test_logs(min_level = ProgressLogging.ProgressLevel) do
+        ProgressLogging.@withprogress ProgressLogging.@logprogress "hello" 0.1
+    end
+    @test length(logs) == 3
+    @test logs[1].kwargs[:progress] === NaN
+    @test logs[2].kwargs[:progress] === 0.1
+    @test logs[3].kwargs[:progress] === "done"
+    @test logs[1].message == ""
+    @test logs[2].message == "hello"
+    @test logs[3].message == ""
+    @test [l.message.progress.fraction for l in logs] == [nothing, 0.1, nothing]
+    @test [l.message.progress.done for l in logs] == [false, false, true]
+    @test length(unique([l.message.progress.id for l in logs])) == 1
+    @test length(unique([l.id for l in logs])) == 1
+    @test unique([l.message.progress.parentid for l in logs]) == [ProgressLogging.ROOTID]
+end
+end  # module IsolatedNamespace
+
 end  # module

--- a/test/test_withprogress_macro.jl
+++ b/test/test_withprogress_macro.jl
@@ -2,7 +2,7 @@ module TestWithprogressMacro
 
 using Logging
 using ProgressLogging
-using ProgressLogging: ProgressLevel
+using ProgressLogging: ProgressLevel, ROOTID
 using Test
 using Test: collect_test_logs
 
@@ -17,7 +17,11 @@ using Test: collect_test_logs
     @test logs[1].message == ""
     @test logs[2].message == "hello"
     @test logs[3].message == ""
+    @test [l.message.progress.fraction for l in logs] == [nothing, 0.1, nothing]
+    @test [l.message.progress.done for l in logs] == [false, false, true]
+    @test length(unique([l.message.progress.id for l in logs])) == 1
     @test length(unique([l.id for l in logs])) == 1
+    @test unique([l.message.progress.parentid for l in logs]) == [ROOTID]
 end
 
 @testset "specify name in `@withprogress`" begin
@@ -31,7 +35,11 @@ end
     @test logs[1].message == "hello"
     @test logs[2].message == "hello"
     @test logs[3].message == "hello"
+    @test [l.message.progress.fraction for l in logs] == [nothing, 0.1, nothing]
+    @test [l.message.progress.done for l in logs] == [false, false, true]
+    @test length(unique([l.message.progress.id for l in logs])) == 1
     @test length(unique([l.id for l in logs])) == 1
+    @test unique([l.message.progress.parentid for l in logs]) == [ROOTID]
 end
 
 @testset "keyword argument when no name" begin
@@ -43,7 +51,11 @@ end
     @test logs[2].kwargs[:progress] === 0.1
     @test logs[3].kwargs[:progress] === "done"
     @test logs[2].kwargs[:message] === "hello"
+    @test [l.message.progress.fraction for l in logs] == [nothing, 0.1, nothing]
+    @test [l.message.progress.done for l in logs] == [false, false, true]
+    @test length(unique([l.message.progress.id for l in logs])) == 1
     @test length(unique([l.id for l in logs])) == 1
+    @test unique([l.message.progress.parentid for l in logs]) == [ROOTID]
 end
 
 @testset "change name" begin
@@ -57,7 +69,11 @@ end
     @test logs[1].message == "name"
     @test logs[2].message == "hello"
     @test logs[3].message == "name"
+    @test [l.message.progress.fraction for l in logs] == [nothing, 0.1, nothing]
+    @test [l.message.progress.done for l in logs] == [false, false, true]
+    @test length(unique([l.message.progress.id for l in logs])) == 1
     @test length(unique([l.id for l in logs])) == 1
+    @test unique([l.message.progress.parentid for l in logs]) == [ROOTID]
 end
 
 @testset "nested" begin
@@ -75,14 +91,24 @@ end
     ids = unique([l.id for l in logs])
     @test length(ids) == 2
 
-    @test Tuple((l.id, string(l.message), l.kwargs[:progress]) for l in logs) === (
-        (ids[1], "", NaN),
-        (ids[1], "hello", 0.1),
-        (ids[2], "", NaN),
-        (ids[2], "world", 0.2),
-        (ids[2], "", "done"),
-        (ids[1], "", "done"),
+    @test Tuple(
+        (l.id, l.message.progress.parentid, string(l.message), l.kwargs[:progress])
+        for l in logs
+    ) === (
+        (ids[1], ROOTID, "", NaN),
+        (ids[1], ROOTID, "hello", 0.1),
+        (ids[2], ids[1], "", NaN),
+        (ids[2], ids[1], "world", 0.2),
+        (ids[2], ids[1], "", "done"),
+        (ids[1], ROOTID, "", "done"),
     )
+end
+
+@testset "`@logprogress 1.0` is not `done`" begin
+    logs, = collect_test_logs(min_level = ProgressLevel) do
+        @withprogress @logprogress 1.0
+    end
+    @test [l.message.progress.done for l in logs] == [false, false, true]
 end
 
 @testset "invalid input" begin

--- a/test/test_withprogress_macro.jl
+++ b/test/test_withprogress_macro.jl
@@ -75,7 +75,7 @@ end
     ids = unique([l.id for l in logs])
     @test length(ids) == 2
 
-    @test Tuple((l.id, l.message, l.kwargs[:progress]) for l in logs) === (
+    @test Tuple((l.id, string(l.message), l.kwargs[:progress]) for l in logs) === (
         (ids[1], "", NaN),
         (ids[1], "hello", 0.1),
         (ids[2], "", NaN),
@@ -93,7 +93,7 @@ end
         err
     end isa Exception  # unfortunately `LoadError`, not an `ArgumentError`
     msg = sprint(showerror, err)
-    @test occursin("First expression to @withprogress must be `name=...`.", msg)
+    @test occursin("Unsupported optional arguments:", msg)
     @test occursin("invalid_argument", msg)
 end
 


### PR DESCRIPTION
close #7

This PR implements add `Progress` type that holds the progress value (`fraction`), name, its ID, parent ID, and a flag indicating if the task is finished or not (`done`):

https://github.com/JunoLab/ProgressLogging.jl/blob/d1e1b0ebd9048227bf1dd76141b851c35cc1c8a4/src/ProgressLogging.jl#L65-L71

This API is based on @c42f's suggestion https://github.com/JunoLab/ProgressLogging.jl/issues/7#issuecomment-553249772 and I added `Base.print(::IO, ::Progress)` method to it.  This way, the progress information is somewhat readable even without proper progress monitor:

```julia
julia> @info Progress(uuid4(), 0.1)
[ Info: Progress: 10%
```

There is a bit of machinery in `@logprogress` to help producing log record that is compatible with both old (untyped) and new (typed) APIs.

Here is an example of nested progress bar handling implemented in TerminalLoggers.jl https://github.com/c42f/TerminalLoggers.jl/pull/13

![Peek 2020-01-26 19-04](https://user-images.githubusercontent.com/29282/73147930-b2e2a700-406e-11ea-8b25-9f59adc43859.gif)
