### PR TITLE
Use at-withprogress etc. in at-progress

### DIFF
--- a/src/ProgressLogging.jl
+++ b/src/ProgressLogging.jl
@@ -183,7 +183,7 @@ function _progress(name, thresh, ex, target, result, loop, iter_vars, ranges, bo
     quote
         $target = @withprogress name = $(esc(name)) begin
             ranges = $(Expr(:vect, esc.(ranges)...))
-            lens = length.(ranges)
+            lens = map(length, ranges)
             n = prod(lens)
             strides = cumprod([1; lens[1:end-1]])
             _frac(i) = (sum((i - 1) * s for (i, s) in zip(i, strides)) + 1) / n

--- a/src/ProgressLogging.jl
+++ b/src/ProgressLogging.jl
@@ -183,7 +183,6 @@ function _progress(name, thresh, ex, target, result, loop, iter_vars, ranges, bo
     quote
         $target = @withprogress name = $(esc(name)) begin
             ranges = $(Expr(:vect, esc.(ranges)...))
-            nranges = length(ranges)
             lens = length.(ranges)
             n = prod(lens)
             strides = cumprod([1; lens[1:end-1]])


### PR DESCRIPTION
Once we have more machinery in `@logprogress` (as done in #13), it makes sense to use it inside `@progress`.  However, this PR as-is has a hygiene issue when combined with #13. I think this because it does not pick up parent ID correctly as the variable name is doubly mangled.  When I have hygiene issue I usually just give up and manually `gensym`.  But is there a better way to do it?
