### PR TITLE
Fix Travis: Documenter hasn't been running

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,15 @@ julia:
   - 1.0
   - 1.3
   - nightly
-matrix:
-  allow_failures:
-    - julia: nightly
-  fast_finish: true
 notifications:
   email: false
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
 jobs:
+  allow_failures:
+    - julia: nightly
+  fast_finish: true
   include:
     - stage: Documentation
       julia: 1.3


### PR DESCRIPTION
e.g. https://travis-ci.com/JunoLab/ProgressLogging.jl/builds/148148460

It looks like Travis stopped accepting `matrix` and `job` mixed in a `.travis.yml` file.
