### PR TITLE
Stop mentioning ConsoleProgressMonitor.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,3 @@ progress logs created by ProgressLogging.jl API.  For example:
 
 * [Juno](https://junolab.org/)
 * [TerminalLoggers.jl](https://github.com/c42f/TerminalLoggers.jl)
-* [ConsoleProgressMonitor.jl](https://github.com/tkf/ConsoleProgressMonitor.jl)


### PR DESCRIPTION
as TerminalLoggers.jl supersedes it.

ref https://github.com/tkf/ConsoleProgressMonitor.jl/issues/9