### PR TITLE
New API: ProgressLogging.implementedby(logger)

### DIFF
--- a/src/ProgressLogging.jl
+++ b/src/ProgressLogging.jl
@@ -151,6 +151,8 @@ function Logging.handle_message(logger::MyLogger, args...; kwargs...)
     # handle normal log record
 end
 ```
+
+Progress monitors also should define [`implemented_by`](@ref).
 """
 asprogress(_level, progress::Progress, _args...; _...) = progress
 function asprogress(
@@ -505,5 +507,21 @@ function make_count_to_frac(iterators...)
     end
     return count_to_frac
 end
+
+"""
+    ProgressLogging.implemented_by(logger::AbstractLogger) :: Bool
+
+Check if ProgressLogging protocol is supported by `logger`.
+
+# Implementation
+
+A progress monitor `CustomLogger <: AbstractLogger` should define
+
+```julia
+ProgressLogging.implemented_by(::CustomLogger) = true
+```
+"""
+implemented_by
+implemented_by(@nospecialize(logger::Logging.AbstractLogger)) = false
 
 end # module

--- a/src/ProgressLogging.jl
+++ b/src/ProgressLogging.jl
@@ -152,7 +152,7 @@ function Logging.handle_message(logger::MyLogger, args...; kwargs...)
 end
 ```
 
-Progress monitors also should define [`implemented_by`](@ref).
+Progress monitors also should define [`implementedby`](@ref).
 """
 asprogress(_level, progress::Progress, _args...; _...) = progress
 function asprogress(
@@ -509,7 +509,7 @@ function make_count_to_frac(iterators...)
 end
 
 """
-    ProgressLogging.implemented_by(logger::AbstractLogger) :: Bool
+    ProgressLogging.implementedby(logger::AbstractLogger) :: Bool
 
 Check if ProgressLogging protocol is supported by `logger`.
 
@@ -518,10 +518,10 @@ Check if ProgressLogging protocol is supported by `logger`.
 A progress monitor `CustomLogger <: AbstractLogger` should define
 
 ```julia
-ProgressLogging.implemented_by(::CustomLogger) = true
+ProgressLogging.implementedby(::CustomLogger) = true
 ```
 """
-implemented_by
-implemented_by(@nospecialize(logger::Logging.AbstractLogger)) = false
+implementedby
+implementedby(@nospecialize(logger::Logging.AbstractLogger)) = false
 
 end # module

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -1,0 +1,11 @@
+module TestMisc
+
+using ProgressLogging
+using Test
+using Logging
+
+@testset "implemented_by" begin
+    @test ProgressLogging.implemented_by(NullLogger()) == false
+end
+
+end  # module

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -4,8 +4,8 @@ using ProgressLogging
 using Test
 using Logging
 
-@testset "implemented_by" begin
-    @test ProgressLogging.implemented_by(NullLogger()) == false
+@testset "implementedby" begin
+    @test ProgressLogging.implementedby(NullLogger()) == false
 end
 
 end  # module


### PR DESCRIPTION
This is useful for progress log record providers to check if users have progress monitors.  Ref: https://github.com/JuliaDiffEq/DiffEqBase.jl/pull/450#issuecomment-596315679

Originally I called it `enabled_for`. But I think `implementedby` makes more sense. For example, the user may turn off progress logging capability for a particular instance of a custom logger type. In this case, the name `enabled_for` implies that this function should return `false`. But if this function is used by log record providers, they may take action incompatible to the user's intent (e.g., warning message telling the user that the current logger does not support progress bar).
