### PR TITLE
Ducktyping

### DIFF
--- a/src/ProgressLogging.jl
+++ b/src/ProgressLogging.jl
@@ -164,18 +164,22 @@ function asprogress(
     progress = undef,  # `undef` is an arbitrary unsupported value
     kwargs...,
 )
-    if hasfield(typeof(name), :progress)
-        return Progress((getfield(name.progress, f) for f in fieldnames(Progress))...)
+    if hasfield(typeof(name), :progress) && is_progresslike(name.progress)
+        return _asprogress(name.progress)
     end
     if progress isa Union{Nothing,Real,AbstractString}
         return _asprogress(name, id; progress = progress, kwargs...)
     else
-        if fieldnames(typeof(progress)) == fieldnames(Progress)
-            return Progress((getfield(progress, f) for f in fieldnames(Progress))...)
+        if is_progresslike(progress)
+            return _asprogress(progress)
         end
         return nothing
     end
 end
+
+is_progresslike(_::T) where {T} = all(in.(fieldnames(Progress), Ref(fieldnames(T))))
+
+_asprogress(progress) = Progress((getfield(progress, f) for f in fieldnames(Progress))...)
 
 # `parentid` is used from `@logprogress`.
 function _asprogress(name, id, parentid = ROOTID; progress, _...)

--- a/src/ProgressLogging.jl
+++ b/src/ProgressLogging.jl
@@ -164,9 +164,15 @@ function asprogress(
     progress = undef,  # `undef` is an arbitrary unsupported value
     kwargs...,
 )
+    if hasfield(typeof(name), :progress)
+        return Progress((getfield(name.progress, f) for f in fieldnames(Progress))...)
+    end
     if progress isa Union{Nothing,Real,AbstractString}
         return _asprogress(name, id; progress = progress, kwargs...)
     else
+        if fieldnames(typeof(progress)) == fieldnames(Progress)
+            return Progress((getfield(progress, f) for f in fieldnames(Progress))...)
+        end
         return nothing
     end
 end


### PR DESCRIPTION
Ok, this may look a bit weird, but makes sure we support arbitrary objects (with the right fields) instead of only this package's `Progress` object.

The motivation for this is to add a nice progress frontend for VSCode while re-using `ProgressLogging.asprogress` and _without_ forcing a specific version to be loaded (we're not loading this as a package in VSCode, only `include` the main file). 